### PR TITLE
Refactor script

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -29,7 +29,7 @@ def runCmd (cmd : String) (args : Array String) : ScriptM Bool := do
   return hasError
 
 script build do
-  if ← runCmd "lake exe mdgen" #["Src", "md"] then return 1
-  if ← runCmd "lake exe import_all" #["Src"] then return 1
-  if ← runCmd "mdbook build" #[] then return 1
+  if ← runCmd "lake" #["exe", "mdgen", "Src", "md"] then return 1
+  if ← runCmd "lake" #["exe", "import_all", "Src"] then return 1
+  if ← runCmd "mdbook" #["build"] then return 1
   return 0


### PR DESCRIPTION
Refactor script to make sure the arguments to the function `runCmd` are understood by the OS (first a single `String` for the main command, without spaces, then an array of strings for additional arguments).